### PR TITLE
Slate 2 Compatibility

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -37,7 +37,7 @@
     margin-bottom: -8px;
     // text area
     .textArea-2CLwUE > div {
-        left: 16px;
+        padding-left: 16px;
     }
     .scrollableContainer-15eg7h {
         margin-right: -12px;


### PR DESCRIPTION
Discord is migrating to Slate 2. As such, the following no longer works:
https://github.com/Discord-Theme-Addons/bubble-bar/blob/f81386f15801db62edfcbc90a9e3061b3a27c256/src/_theme.scss#L39-L41
`padding-left` works fine on both Slate 1 and 2 with no apparent consequences.